### PR TITLE
GUI: Option to use split time controls for White and Black in individ…

### DIFF
--- a/projects/gui/src/gamesettingswidget.h
+++ b/projects/gui/src/gamesettingswidget.h
@@ -43,6 +43,7 @@ class GameSettingsWidget : public QWidget
 
 		QString chessVariant() const;
 		TimeControl timeControl() const;
+		TimeControl timeControl2() const;
 		bool pondering() const;
 		GameAdjudicator adjudicator() const;
 		OpeningSuite* openingSuite() const;
@@ -53,6 +54,7 @@ class GameSettingsWidget : public QWidget
 
 		void applyEngineConfiguration(EngineConfiguration* config);
 		void enableSettingsUpdates();
+		void enableSplitTimeControls(bool enable);
 
 	public slots:
 		void onHumanCountChanged(int count);
@@ -68,9 +70,12 @@ class GameSettingsWidget : public QWidget
 
 	private:
 		void readSettings();
+		void updateButtonText();
 
 		Ui::GameSettingsWidget *ui;
+		bool m_splitTimeControls;
 		TimeControl m_timeControl;
+		TimeControl m_timeControl2;
 		Chess::Board* m_board;
 		QPalette m_defaultPalette;
 		bool m_isValid;

--- a/projects/gui/src/newgamedlg.cpp
+++ b/projects/gui/src/newgamedlg.cpp
@@ -47,6 +47,7 @@ NewGameDialog::NewGameDialog(EngineManager* engineManager, QWidget* parent)
 {
 	Q_ASSERT(engineManager != nullptr);
 	ui->setupUi(this);
+	ui->m_gameSettings->enableSplitTimeControls(true);
 
 	m_engines = new EngineConfigurationModel(m_engineManager, this);
 	#ifdef QT_DEBUG
@@ -112,7 +113,9 @@ ChessGame* NewGameDialog::createGame() const
 	pgn->setSite(QSettings().value("pgn/site").toString());
 	auto game = new ChessGame(board, pgn);
 
-	game->setTimeControl(ui->m_gameSettings->timeControl());
+	game->setTimeControl(ui->m_gameSettings->timeControl(), Chess::Side::White);
+	game->setTimeControl(ui->m_gameSettings->timeControl2(), Chess::Side::Black);
+
 	game->setAdjudicator(ui->m_gameSettings->adjudicator());
 
 	auto suite = ui->m_gameSettings->openingSuite();

--- a/projects/gui/src/newtournamentdialog.cpp
+++ b/projects/gui/src/newtournamentdialog.cpp
@@ -20,6 +20,7 @@
 
 #include <QFileDialog>
 #include <QSettings>
+#include <QMenu>
 #include <functional>
 #include <algorithm>
 
@@ -112,6 +113,10 @@ NewTournamentDialog::NewTournamentDialog(EngineManager* engineManager,
 	connect(ui->m_playersList, SIGNAL(doubleClicked(QModelIndex)),
 		this, SLOT(configureEngine(QModelIndex)));
 
+	ui->m_playersList->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
+	connect(ui->m_playersList, SIGNAL(customContextMenuRequested(const QPoint&)),
+		this, SLOT(onContextMenuRequest()));
+
 	ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 	connect(ui->m_gameSettings, &GameSettingsWidget::statusChanged, [=](bool ok)
 	{
@@ -136,6 +141,7 @@ void NewTournamentDialog::addEngineOnDblClick(const QModelIndex& index)
 	const QModelIndex& idx = m_proxyModel->mapToSource(index);
 
 	m_addedEnginesManager->addEngine(m_srcEngineManager->engineAt(idx.row()));
+	m_timeControls << TimeControl();
 	listView->selectionModel()->select(index, QItemSelectionModel::Deselect);
 
 	QPushButton* button = ui->buttonBox->button(QDialogButtonBox::Ok);
@@ -157,7 +163,10 @@ void NewTournamentDialog::addEngine()
 
 	const QModelIndexList list(dlg.selection().indexes());
 	for (const QModelIndex& index : list)
+	{
 		m_addedEnginesManager->addEngine(m_srcEngineManager->engineAt(index.row()));
+		m_timeControls << TimeControl();
+	}
 
 	QPushButton* button = ui->buttonBox->button(QDialogButtonBox::Ok);
 	button->setEnabled(canStart());
@@ -176,7 +185,10 @@ void NewTournamentDialog::removeEngine()
 	});
 
 	for (const QModelIndex& index : qAsConst(selected))
+	{
 		m_addedEnginesManager->removeEngineAt(index.row());
+		m_timeControls.remove(index.row());
+	}
 
 	QPushButton* button = ui->buttonBox->button(QDialogButtonBox::Ok);
 	button->setEnabled(canStart());
@@ -207,9 +219,13 @@ void NewTournamentDialog::moveEngine(int offset)
 	int row1 = index.row();
 	int row2 = row1 + offset;
 	EngineConfiguration tmp(m_addedEnginesManager->engineAt(row1));
+	TimeControl tc = m_timeControls.at(row1);
 
 	m_addedEnginesManager->updateEngineAt(row1, m_addedEnginesManager->engineAt(row2));
 	m_addedEnginesManager->updateEngineAt(row2, tmp);
+
+	m_timeControls[row1] = m_timeControls.at(row2);
+	m_timeControls[row2]= tc;
 
 	ui->m_playersList->setCurrentIndex(index.sibling(row2, 0));
 }
@@ -264,6 +280,37 @@ void NewTournamentDialog::onPlayerSelectionChanged(const QItemSelection& selecte
 	ui->m_moveEngineDownBtn->setEnabled(enable && i < m_addedEnginesManager->engineCount() - 1);
 }
 
+void NewTournamentDialog::onContextMenuRequest()
+{
+	QList<QModelIndex> selected = ui->m_playersList->selectionModel()->selectedRows();
+	if (selected.isEmpty())
+		return;
+
+	QMenu menu(ui->m_playersList);
+
+	auto editTimeControlAct = menu.addAction(tr("Edit Time Control"));
+	connect(editTimeControlAct, &QAction::triggered, this, [=]()
+	{
+		int i = selected.first().row();
+		TimeControl tc {m_timeControls.at(i)};
+		if (!tc.isValid())
+			tc = ui->m_gameSettings->timeControl();
+
+		auto dlg = new TimeControlDialog(tc);
+		QString name {m_addedEnginesManager->engines().at(i).name()};
+		if (selected.count() > 1)
+			name.append(tr(" - %0 engines").arg(selected.count()));
+		dlg->setWindowTitle(tr("Time Control - %0").arg(name));
+
+		if (dlg->exec() == QDialog::Accepted)
+			for (QModelIndex index: selected)
+				m_timeControls[index.row()] = dlg->timeControlWhite();
+		delete dlg;
+	});
+
+	menu.exec(QCursor::pos());
+}
+
 Tournament* NewTournamentDialog::createTournament(GameManager* gameManager) const
 {
 	Q_ASSERT(gameManager != nullptr);
@@ -300,12 +347,19 @@ Tournament* NewTournamentDialog::createTournament(GameManager* gameManager) cons
 	t->setSwapSides(ts->swappingSides());
 	t->setResultFormat(ts->resultFormat());
 
+	bool isHourglass = ui->m_gameSettings->timeControl().isHourglass();
+
 	const auto engines = m_addedEnginesManager->engines();
-	for (EngineConfiguration config : engines)
+	for (int i = 0; i < engines.count(); i++)
 	{
+		EngineConfiguration config = engines.at(i);
 		ui->m_gameSettings->applyEngineConfiguration(&config);
+		TimeControl tc = m_timeControls.at(i);
+		// Hourglass mode must be the same for all players
+		tc.setHourglass(isHourglass);
+
 		t->addPlayer(new EngineBuilder(config),
-			     ui->m_gameSettings->timeControl(),
+			     tc.isValid() ? tc : ui->m_gameSettings->timeControl(),
 			     book,
 			     bookDepth);
 	}

--- a/projects/gui/src/newtournamentdialog.h
+++ b/projects/gui/src/newtournamentdialog.h
@@ -53,6 +53,7 @@ class NewTournamentDialog : public QDialog
 		void onVariantChanged(const QString& variant);
 		void onPlayerSelectionChanged(const QItemSelection& selected,
 					      const QItemSelection& deselected);
+		void onContextMenuRequest();
 	
 	private:
 		void moveEngine(int offset);
@@ -64,6 +65,7 @@ class NewTournamentDialog : public QDialog
 		EngineConfigurationModel* m_srcEnginesModel;
 		EngineConfigurationModel* m_addedEnginesModel;
 		EngineConfigurationProxyModel* m_proxyModel;
+		QVector<TimeControl> m_timeControls;
 		Ui::NewTournamentDialog* ui;
 };
 

--- a/projects/gui/src/settingsdlg.cpp
+++ b/projects/gui/src/settingsdlg.cpp
@@ -29,6 +29,7 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 	  ui(new Ui::SettingsDialog)
 {
 	ui->setupUi(this);
+	ui->m_gameSettings->enableSplitTimeControls(true);
 
 	readSettings();
 

--- a/projects/gui/src/src.pri
+++ b/projects/gui/src/src.pri
@@ -18,6 +18,7 @@ HEADERS += $$PWD/chessclock.h \
     $$PWD/engineoptiondelegate.h \
     $$PWD/engineoptionmodel.h \
     $$PWD/gamedatabasesearchdlg.h \
+    $$PWD/timecontrolwidget.h \
     $$PWD/timecontroldlg.h \
     $$PWD/engineconfigproxymodel.h \
     $$PWD/gamewall.h \
@@ -62,6 +63,7 @@ SOURCES += $$PWD/main.cpp \
     $$PWD/engineoptiondelegate.cpp \
     $$PWD/engineoptionmodel.cpp \
     $$PWD/gamedatabasesearchdlg.cpp \
+    $$PWD/timecontrolwidget.cpp \
     $$PWD/timecontroldlg.cpp \
     $$PWD/engineconfigproxymodel.cpp \
     $$PWD/gamewall.cpp \

--- a/projects/gui/src/timecontrolwidget.cpp
+++ b/projects/gui/src/timecontrolwidget.cpp
@@ -1,0 +1,202 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "timecontrolwidget.h"
+#include "ui_timecontrolwidget.h"
+
+
+TimeControlWidget::TimeControlWidget(QWidget *parent)
+	: QWidget(parent),
+	  ui(new Ui::TimeControlWidget)
+{
+	ui->setupUi(this);
+}
+
+void TimeControlWidget::init(const TimeControl& tc)
+{
+	connect(ui->m_tournamentRadio, SIGNAL(clicked()),
+		this, SLOT(onTournamentSelected()));
+	connect(ui->m_timePerMoveRadio, SIGNAL(clicked()),
+		this, SLOT(onTimePerMoveSelected()));
+	connect(ui->m_infiniteRadio, SIGNAL(clicked()),
+		this, SLOT(onInfiniteSelected()));
+	connect(ui->m_hourglassRadio, SIGNAL(clicked()),
+		this, SLOT(onHourglassSelected()));
+	connect(ui->m_hourglassRadio, SIGNAL(toggled(bool)),
+		this, SIGNAL(hourglassToggled(bool)));
+
+	if (!tc.isValid())
+		return;
+
+	if (tc.isInfinite())
+	{
+		ui->m_infiniteRadio->setChecked(true);
+		onInfiniteSelected();
+	}
+	else if (tc.isHourglass())
+	{
+		ui->m_hourglassRadio->setChecked(true);
+		setTime(tc.timePerTc());
+		onHourglassSelected();
+	}
+	else if (tc.timePerMove() != 0)
+	{
+		ui->m_timePerMoveRadio->setChecked(true);
+		setTime(tc.timePerMove());
+		onTimePerMoveSelected();
+	}
+	else
+	{
+		ui->m_tournamentRadio->setChecked(true);
+		ui->m_movesSpin->setValue(tc.movesPerTc());
+		ui->m_incrementSpin->setValue(double(tc.timeIncrement()) / 1000.0);
+		setTime(tc.timePerTc());
+		onTournamentSelected();
+	}
+
+	ui->m_nodesSpin->setValue(tc.nodeLimit());
+	ui->m_pliesSpin->setValue(tc.plyLimit());
+	ui->m_marginSpin->setValue(tc.expiryMargin());
+}
+
+TimeControlWidget::~TimeControlWidget()
+{
+	delete ui;
+}
+
+void TimeControlWidget::onTournamentSelected()
+{
+	ui->m_movesSpin->setEnabled(true);
+	ui->m_timeSpin->setEnabled(true);
+	ui->m_timeUnitCombo->setEnabled(true);
+	ui->m_incrementSpin->setEnabled(true);
+	ui->m_marginSpin->setEnabled(true);
+}
+
+void TimeControlWidget::onTimePerMoveSelected()
+{
+	ui->m_movesSpin->setEnabled(false);
+	ui->m_timeSpin->setEnabled(true);
+	ui->m_timeUnitCombo->setEnabled(true);
+	ui->m_incrementSpin->setEnabled(false);
+	ui->m_marginSpin->setEnabled(true);
+}
+
+void TimeControlWidget::onInfiniteSelected()
+{
+	ui->m_movesSpin->setEnabled(false);
+	ui->m_timeSpin->setEnabled(false);
+	ui->m_timeUnitCombo->setEnabled(false);
+	ui->m_incrementSpin->setEnabled(false);
+	ui->m_marginSpin->setEnabled(false);
+}
+
+void TimeControlWidget::onHourglassSelected()
+{
+	ui->m_movesSpin->setEnabled(false);
+	ui->m_timeSpin->setEnabled(true);
+	ui->m_timeUnitCombo->setEnabled(true);
+	ui->m_incrementSpin->setEnabled(false);
+	ui->m_marginSpin->setEnabled(true);
+}
+
+void TimeControlWidget::setHourglassMode(bool enabled)
+{
+	ui->m_groupBox->setEnabled(!enabled);
+
+	if (enabled)
+	{
+		ui->m_hourglassRadio->setChecked(true);
+		onHourglassSelected();
+	}
+	else
+	{
+		ui->m_tournamentRadio->setChecked(true);
+		onTournamentSelected();
+	}
+}
+
+void TimeControlWidget::disableHourglassRadio()
+{
+	ui->m_hourglassRadio->setEnabled(false);
+	if (ui->m_hourglassRadio->isChecked())
+		ui->m_groupBox->setEnabled(false);
+}
+
+int TimeControlWidget::timeToMs() const
+{
+	switch (ui->m_timeUnitCombo->currentIndex())
+	{
+	case Seconds:
+		return ui->m_timeSpin->value() * 1000.0;
+	case Minutes:
+		return ui->m_timeSpin->value() * 60000.0;
+	case Hours:
+		return ui->m_timeSpin->value() * 3600000.0;
+	default:
+		return 0;
+	}
+}
+
+void TimeControlWidget::setTime(int ms)
+{
+	Q_ASSERT(ms >= 0);
+
+	if (ms == 0 || ms % 60000 != 0)
+	{
+		ui->m_timeUnitCombo->setCurrentIndex(Seconds);
+		ui->m_timeSpin->setValue(double(ms) / 1000.0);
+	}
+	else if (ms % 3600000 != 0)
+	{
+		ui->m_timeUnitCombo->setCurrentIndex(Minutes);
+		ui->m_timeSpin->setValue(double(ms) / 60000.0);
+	}
+	else
+	{
+		ui->m_timeUnitCombo->setCurrentIndex(Hours);
+		ui->m_timeSpin->setValue(double(ms) / 3600000.0);
+	}
+}
+
+TimeControl TimeControlWidget::timeControl() const
+{
+	TimeControl tc;
+	if (ui->m_infiniteRadio->isChecked())
+		tc.setInfinity(true);
+	else if (ui->m_timePerMoveRadio->isChecked())
+		tc.setTimePerMove(timeToMs());
+	else if (ui->m_tournamentRadio->isChecked())
+	{
+		tc.setMovesPerTc(ui->m_movesSpin->value());
+		tc.setTimePerTc(timeToMs());
+		tc.setTimeIncrement(ui->m_incrementSpin->value() * 1000.0);
+	}
+	else if (ui->m_hourglassRadio->isChecked())
+	{
+		tc.setHourglass(true);
+		tc.setTimePerTc(timeToMs());
+		tc.setTimeIncrement(0);
+	}
+
+	tc.setNodeLimit(ui->m_nodesSpin->value());
+	tc.setPlyLimit(ui->m_pliesSpin->value());
+	tc.setExpiryMargin(ui->m_marginSpin->value());
+
+	return tc;
+}

--- a/projects/gui/src/timecontrolwidget.h
+++ b/projects/gui/src/timecontrolwidget.h
@@ -16,42 +16,63 @@
     along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef TIMECONTROLDIALOG_H
-#define TIMECONTROLDIALOG_H
+#ifndef TIMECONTROLWIDGET_H
+#define TIMECONTROLWIDGET_H
 
-#include <QDialog>
+#include <QWidget>
 #include <timecontrol.h>
 
 namespace Ui {
-	class TimeControlDialog;
+	class TimeControlWidget;
 }
 
 /*!
  * \brief A dialog for setting a chess game's time controls
  */
-class TimeControlDialog : public QDialog
+class TimeControlWidget : public QWidget
 {
 	Q_OBJECT
 
 	public:
 		/*!
-		 * Creates a new time control dialog.
+		 * Creates a new time control widget.
 		 *
-		 * The dialog is initialized according to \a tc1,
-		 * and \a tc2
+		 * The widget is initialized according to \a tc.
 		 */
-		explicit TimeControlDialog(const TimeControl& tc1,
-					   const TimeControl& tc2 = TimeControl(),
-					   QWidget* parent = nullptr);
+		explicit TimeControlWidget(QWidget *parent = nullptr);
 		/*! Destroys the dialog. */
-		virtual ~TimeControlDialog();
+		virtual ~TimeControlWidget();
 
+		/*! Initialise time contol, signals and slots */
+		void init(const TimeControl& tc);
 		/*! Returns the time control that was set in the dialog. */
-		TimeControl timeControlWhite() const;
-		TimeControl timeControlBlack() const;
+		TimeControl timeControl() const;
+
+	signals:
+		void hourglassToggled(bool);
+
+	public slots: void setHourglassMode(bool enabled);
+		      void disableHourglassRadio();
+
+	private slots:
+		void onTournamentSelected();
+		void onTimePerMoveSelected();
+		void onInfiniteSelected();
+		void onHourglassSelected();
 
 	private:
-		Ui::TimeControlDialog *ui;
+		enum TimeUnit
+		{
+			Seconds,
+			Minutes,
+			Hours
+		};
+
+		int timeToMs() const;
+		void setTime(int ms);
+
+		Ui::TimeControlWidget *ui;
+		TimeControl m_tc;
 };
 
-#endif // TIMECONTROLDIALOG_H
+#endif // TIMECONTROLWIDGET_H

--- a/projects/gui/ui/timecontroldlg.ui
+++ b/projects/gui/ui/timecontroldlg.ui
@@ -6,264 +6,111 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>289</width>
-    <height>399</height>
+    <width>610</width>
+    <height>462</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Time Controls</string>
+   <string>Time Control</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <property name="sizeConstraint">
-    <enum>QLayout::SetFixedSize</enum>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>430</y>
+     <width>281</width>
+     <height>32</height>
+    </rect>
    </property>
-   <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="autoFillBackground">
-      <bool>false</bool>
-     </property>
-     <property name="title">
-      <string>Mode</string>
-     </property>
-     <property name="flat">
-      <bool>false</bool>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <widget class="QRadioButton" name="m_tournamentRadio">
-        <property name="toolTip">
-         <string>Tournament time control</string>
-        </property>
-        <property name="text">
-         <string>Tournament</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="m_timePerMoveRadio">
-        <property name="toolTip">
-         <string>Fixed time limit for each move</string>
-        </property>
-        <property name="text">
-         <string>Time per move</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="m_infiniteRadio">
-        <property name="toolTip">
-         <string>Infinite thinking time</string>
-        </property>
-        <property name="text">
-         <string>Infinite</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="m_hourglassRadio">
-        <property name="toolTip">
-         <string>Time used is added to opponent's available time</string>
-        </property>
-        <property name="text">
-         <string>Hourglass</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <layout class="QFormLayout" name="formLayout">
-     <property name="fieldGrowthPolicy">
-      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-     </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Moves:</string>
-       </property>
-       <property name="buddy">
-        <cstring>m_movesSpin</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QSpinBox" name="m_movesSpin">
-       <property name="toolTip">
-        <string>The number of moves in a time control</string>
-       </property>
-       <property name="specialValueText">
-        <string>Whole game</string>
-       </property>
-       <property name="maximum">
-        <number>9999</number>
-       </property>
-       <property name="value">
-        <number>0</number>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Time:</string>
-       </property>
-       <property name="buddy">
-        <cstring>m_timeSpin</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QDoubleSpinBox" name="m_timeSpin">
-         <property name="toolTip">
-          <string>Time limit for the chosen time control</string>
-         </property>
-         <property name="decimals">
-          <number>2</number>
-         </property>
-         <property name="minimum">
-          <double>0.010000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>10000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>0.010000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="m_timeUnitCombo">
-         <property name="toolTip">
-          <string>Time unit for the time limit</string>
-         </property>
-         <property name="currentIndex">
-          <number>0</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>Seconds</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Minutes</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Hours</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Increment:</string>
-       </property>
-       <property name="buddy">
-        <cstring>m_incrementSpin</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QDoubleSpinBox" name="m_incrementSpin">
-       <property name="toolTip">
-        <string>Time increment per move in seconds</string>
-       </property>
-       <property name="suffix">
-        <string> sec</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QSpinBox" name="m_pliesSpin">
-       <property name="toolTip">
-        <string>Maximum search depth in plies (engines only)</string>
-       </property>
-       <property name="maximum">
-        <number>999</number>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Plies:</string>
-       </property>
-       <property name="buddy">
-        <cstring>m_pliesSpin</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QSpinBox" name="m_nodesSpin">
-       <property name="toolTip">
-        <string>Maximum number of nodes to search (engines only)</string>
-       </property>
-       <property name="maximum">
-        <number>2147483647</number>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Nodes:</string>
-       </property>
-       <property name="buddy">
-        <cstring>m_nodesSpin</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QSpinBox" name="m_marginSpin">
-       <property name="toolTip">
-        <string>The time limit can be exceeded by this many milliseconds</string>
-       </property>
-       <property name="suffix">
-        <string> ms</string>
-       </property>
-       <property name="maximum">
-        <number>9999</number>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Margin:</string>
-       </property>
-       <property name="buddy">
-        <cstring>m_marginSpin</cstring>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-  </layout>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QGroupBox" name="m_timeControlGroupBoxWhite">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>20</y>
+     <width>282</width>
+     <height>409</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string>Select common or separate time controls</string>
+   </property>
+   <property name="title">
+    <string>Both Sides</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <widget class="TimeControlWidget" name="m_timeControlWidgetWhite" native="true">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>19</y>
+      <width>281</width>
+      <height>371</height>
+     </rect>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QGroupBox" name="m_timeControlGroupBoxBlack">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>310</x>
+     <y>20</y>
+     <width>291</width>
+     <height>409</height>
+    </rect>
+   </property>
+   <property name="accessibleDescription">
+    <string>Time Control for 2nd Player</string>
+   </property>
+   <property name="title">
+    <string>B&amp;lack</string>
+   </property>
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <widget class="TimeControlWidget" name="m_timeControlWidgetBlack" native="true">
+    <property name="enabled">
+     <bool>false</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>20</y>
+      <width>281</width>
+      <height>371</height>
+     </rect>
+    </property>
+   </widget>
+  </widget>
+  <zorder>m_timeControlGroupBoxBlack</zorder>
+  <zorder>buttonBox</zorder>
+  <zorder>m_timeControlGroupBoxWhite</zorder>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TimeControlWidget</class>
+   <extends>QWidget</extends>
+   <header>src/timecontrolwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/projects/gui/ui/timecontrolwidget.ui
+++ b/projects/gui/ui/timecontrolwidget.ui
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TimeControlWidget</class>
+ <widget class="QWidget" name="TimeControlWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>291</width>
+    <height>372</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QGroupBox" name="m_groupBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>271</width>
+     <height>157</height>
+    </rect>
+   </property>
+   <property name="autoFillBackground">
+    <bool>false</bool>
+   </property>
+   <property name="title">
+    <string>Mode</string>
+   </property>
+   <property name="flat">
+    <bool>false</bool>
+   </property>
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout_3">
+    <item>
+     <widget class="QRadioButton" name="m_tournamentRadio">
+      <property name="toolTip">
+       <string>Tournament time control</string>
+      </property>
+      <property name="text">
+       <string>To&amp;urnament</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QRadioButton" name="m_timePerMoveRadio">
+      <property name="toolTip">
+       <string>Fixed time limit for each move</string>
+      </property>
+      <property name="text">
+       <string>Time &amp;per move</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QRadioButton" name="m_infiniteRadio">
+      <property name="toolTip">
+       <string>Infinite thinking time</string>
+      </property>
+      <property name="text">
+       <string>Infinite</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QRadioButton" name="m_hourglassRadio">
+      <property name="toolTip">
+       <string>Time used is added to opponent's available time</string>
+      </property>
+      <property name="text">
+       <string>Hourglass</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="layoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>172</y>
+     <width>271</width>
+     <height>190</height>
+    </rect>
+   </property>
+   <layout class="QFormLayout" name="formLayout">
+    <property name="fieldGrowthPolicy">
+     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+    </property>
+    <item row="0" column="0">
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Mo&amp;ves:</string>
+      </property>
+      <property name="buddy">
+       <cstring>m_movesSpin</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QSpinBox" name="m_movesSpin">
+      <property name="toolTip">
+       <string>The number of moves in a time control</string>
+      </property>
+      <property name="specialValueText">
+       <string>Whole game</string>
+      </property>
+      <property name="maximum">
+       <number>9999</number>
+      </property>
+      <property name="value">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="label_2">
+      <property name="text">
+       <string>Time:</string>
+      </property>
+      <property name="buddy">
+       <cstring>m_timeSpin</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QDoubleSpinBox" name="m_timeSpin">
+        <property name="toolTip">
+         <string>Time limit for the chosen time control</string>
+        </property>
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="minimum">
+         <double>0.010000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.010000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="m_timeUnitCombo">
+        <property name="toolTip">
+         <string>Time unit for the time limit</string>
+        </property>
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <item>
+         <property name="text">
+          <string>Seconds</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Minutes</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Hours</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="label_3">
+      <property name="text">
+       <string>In&amp;crement:</string>
+      </property>
+      <property name="buddy">
+       <cstring>m_incrementSpin</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QDoubleSpinBox" name="m_incrementSpin">
+      <property name="toolTip">
+       <string>Time increment per move in seconds</string>
+      </property>
+      <property name="suffix">
+       <string> sec</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QSpinBox" name="m_pliesSpin">
+      <property name="toolTip">
+       <string>Maximum search depth in plies (engines only)</string>
+      </property>
+      <property name="maximum">
+       <number>999</number>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QLabel" name="label_5">
+      <property name="text">
+       <string>P&amp;lies:</string>
+      </property>
+      <property name="buddy">
+       <cstring>m_pliesSpin</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QSpinBox" name="m_nodesSpin">
+      <property name="toolTip">
+       <string>Maximum number of nodes to search (engines only)</string>
+      </property>
+      <property name="maximum">
+       <number>2147483647</number>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="label_4">
+      <property name="text">
+       <string>Nodes:</string>
+      </property>
+      <property name="buddy">
+       <cstring>m_nodesSpin</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="1">
+     <widget class="QSpinBox" name="m_marginSpin">
+      <property name="toolTip">
+       <string>The time limit can be exceeded by this many milliseconds</string>
+      </property>
+      <property name="suffix">
+       <string> ms</string>
+      </property>
+      <property name="maximum">
+       <number>9999</number>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="0">
+     <widget class="QLabel" name="label_6">
+      <property name="text">
+       <string>Mar&amp;gin:</string>
+      </property>
+      <property name="buddy">
+       <cstring>m_marginSpin</cstring>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/gui/ui/ui.pri
+++ b/projects/gui/ui/ui.pri
@@ -5,6 +5,7 @@ FORMS += $$PWD/engineconfigdlg.ui \
 	 $$PWD/gamedatabasedlg.ui \
 	 $$PWD/importprogressdlg.ui \
 	 $$PWD/gamedatabasesearchdlg.ui \
+	 $$PWD/timecontrolwidget.ui \
 	 $$PWD/timecontroldlg.ui \
 	 $$PWD/newtournamentdlg.ui \
 	 $$PWD/engineselectiondlg.ui \


### PR DESCRIPTION
…ual games

Use the new TimeControlWidget in support of TimeControlDialog.
Enable second TimeControlWidget for Black on demand.
Add timeControl2 to GameSettingsWidget, save/read settings for 2nd control.
Add extra control logic for hourglass mode.

GUI: Option to use individual time controls in tournaments

Add a context menu to the tournament players' list.
Add function to edit time controls individually.
Use a simplified time control dialog (2nd time control unused).
Add QVector of individual time controls to NewTournamentDialog.
Support multi-engine selection for time control updates.
Use an individual time control when valid else tournament controls.
At tournament creation hourglass mode is enabled or disabled uniformly
according to the tournament's common settings.